### PR TITLE
Simplify build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,8 @@ RUN dnf install llvm-devel clang-devel -y
 # Rust dependencies
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
 ENV PATH="/root/.cargo/bin:${PATH}"
-RUN rustup install 1.70
+RUN rustup install 1.69
 RUN rustup target add wasm32-unknown-unknown
-
-# WORKAROUND: Install binaryen
-# This is required to deal with wasm incompatibility issues
-# See: https://stackoverflow.com/questions/71943459/how-can-i-fix-error-happened-while-deserializing-the-module-error
-RUN dnf --releasever=38 install binaryen -y
 
 # Copy project files
 COPY . .

--- a/staking-pool/build.sh
+++ b/staking-pool/build.sh
@@ -3,4 +3,3 @@ set -e
 
 RUSTFLAGS='-C link-arg=-s' cargo build --target wasm32-unknown-unknown --release
 cp target/wasm32-unknown-unknown/release/staking_pool.wasm ./res/
-wasm-opt -Oz --signext-lowering ./res/staking_pool.wasm -o ./res/staking_pool.wasm


### PR DESCRIPTION
According to https://github.com/near/nearcore/issues/9143 we can simplify or build process by downgrading to `rust 1.69`.